### PR TITLE
Add a session-start progress-record protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ dmypy.json
 /.idea
 /.claude/
 /output
+
+# Local, untracked Claude working-progress record (see CLAUDE.md)
+/PROGRESS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,15 @@
 # CLAUDE.md - JEditor Project Guidelines
 
+## Session Start: Check the Progress Record
+
+At the start of every session, check for `PROGRESS.md` in the repo root (a local,
+untracked working-progress record — it is in `.gitignore`).
+
+- If it exists and lists outstanding items, read it first to resume in-progress work.
+- Keep it updated as work progresses; items may span both the JEditor and PyBreeze repos (each item names its repo).
+- **When every item is done, clear it** — reset the file to just its heading and usage note, leaving no stale tasks.
+- If it does not exist and there is multi-step or cross-session work worth tracking, create it.
+
 ## Project Overview
 
 JEditor is a Python-based code editor built with PySide6 (Qt), featuring syntax highlighting, code formatting, plugin system, Git integration, and LangChain-powered AI assistance.


### PR DESCRIPTION
## What changed

Adds a short protocol to `CLAUDE.md`: check for a `PROGRESS.md` in the repo root at the start of a session, resume from it if it lists outstanding items, keep it updated as work progresses, and clear it once everything is done.

`PROGRESS.md` itself is a local, untracked working file — `.gitignore` now covers it — so the record stays on the machine while the protocol that describes it is shared.

Items in that record can span this repo and PyBreeze, so each one names its repo.

## Scope

Documentation and ignore rules only; no source, test, or packaging changes.