### PR TITLE
Fix the toolbar's git branch scan, a plugin download escape, and reversed commit diffs

### DIFF
--- a/je_editor/git_client/git_action.py
+++ b/je_editor/git_client/git_action.py
@@ -98,14 +98,25 @@ class GitService:
         return data
 
     def show_diff_of_commit(self, commit_sha: str) -> str:
+        """
+        取得一個 commit 改了什麼
+        What a commit changed.
+
+        ``a.diff(b)`` 是「從 a 走到 b」，所以要拿 commit 做了什麼，得從它的上一個
+        commit diff 過來；反過來寫會把新增印成刪除。第一個 commit 沒有上一個，改
+        跟空樹比。
+        ``a.diff(b)`` reads as going from a to b, so what a commit did comes from
+        diffing its parent to it; the other way round prints additions as
+        deletions. The first commit has no parent, so it is compared to the empty
+        tree instead.
+
+        :param commit_sha: 要看的 commit / the commit to look at
+        :return: 這個 commit 的 patch / the commit's patch
+        """
         self._ensure_repo()
         commit = self.repo.commit(commit_sha)
-        parent = commit.parents[0] if commit.parents else None
-        if parent is None:
-            null_tree = self.repo.tree(NULL_TREE)
-            diffs = commit.diff(null_tree, create_patch=True)
-        else:
-            diffs = commit.diff(parent, create_patch=True)
+        before = commit.parents[0] if commit.parents else self.repo.tree(NULL_TREE)
+        diffs = before.diff(commit, create_patch=True)
         text = []
         for d in diffs:
             try:

--- a/je_editor/pyside_ui/code/plaintext_code_edit/code_edit_plaintext.py
+++ b/je_editor/pyside_ui/code/plaintext_code_edit/code_edit_plaintext.py
@@ -100,7 +100,13 @@ class _JediCompleteWorker(QObject):
             completions = script.complete(self._line, self._column)
             names = [c.name for c in completions]
             self.finished.emit(names)
-        except Exception:
+        except Exception as error:
+            # jedi 對半寫完的程式碼本來就常拋例外，補全給不出來就算了，不該打斷打字；
+            # 但一直補不出來的時候，日誌裡要有東西可看。
+            # jedi raises readily on half-written code. No completions is an
+            # acceptable answer and must not interrupt typing, but when they never
+            # arrive there has to be something in the log to look at.
+            jeditor_logger.debug(f"jedi completion failed: {error}")
             self.finished.emit([])
 
 

--- a/je_editor/pyside_ui/git_ui/git_client/git_branch_tree_widget.py
+++ b/je_editor/pyside_ui/git_ui/git_client/git_branch_tree_widget.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 
 from PySide6.QtCore import QItemSelection, QTimer, QFileSystemWatcher, Qt
@@ -13,10 +12,6 @@ from je_editor.git_client.git_cli import GitCLI
 from je_editor.pyside_ui.git_ui.git_client.commit_table import CommitTable
 from je_editor.pyside_ui.git_ui.git_client.graph_view import CommitGraphView
 from je_editor.utils.multi_language.multi_language_wrapper import language_wrapper
-
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger(__name__)
-
 
 class GitTreeViewGUI(QWidget):
     """

--- a/je_editor/pyside_ui/git_ui/git_client/git_client_gui.py
+++ b/je_editor/pyside_ui/git_ui/git_client/git_client_gui.py
@@ -349,7 +349,10 @@ class GitGui(QWidget):
             with open(abs_path, 'rb') as f:
                 chunk = f.read(sniff_bytes)
                 return b'\x00' in chunk
-        except Exception:
+        except OSError as error:
+            # 讀不到就當它不是二進位，讓後面的流程照常走
+            # Unreadable is treated as not binary, so the rest carries on as usual
+            jeditor_logger.debug(f"binary sniff skipped for {abs_path}: {error}")
             return False
 
     def _safe_set_diff_text(self, text: str) -> None:

--- a/je_editor/pyside_ui/main_ui/editor/editor_widget.py
+++ b/je_editor/pyside_ui/main_ui/editor/editor_widget.py
@@ -428,7 +428,7 @@ class EditorWidget(QWidget):
                 message_box = QMessageBox(self)
                 message_box.setText(
                     language_wrapper.language_word_dict.get("python_format_checker_only_support_python_message"))
-                message_box.exec_()
+                message_box.exec()
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
         """

--- a/je_editor/pyside_ui/main_ui/main_editor.py
+++ b/je_editor/pyside_ui/main_ui/main_editor.py
@@ -11,7 +11,7 @@ import jedi.settings
 # 匯入 PySide6 (Qt for Python) 的核心模組
 # Import PySide6 core modules
 from PySide6.QtCore import QTimer, QEvent
-from PySide6.QtGui import QCloseEvent, QFontDatabase, QIcon, Qt, QTextCharFormat
+from PySide6.QtGui import QCloseEvent, QIcon, Qt, QTextCharFormat
 from PySide6.QtWidgets import QApplication, QMainWindow, QWidget, QTabWidget, QLabel, QMessageBox
 # 匯入 Qt Material 主題工具
 # Import Qt Material style tools
@@ -141,10 +141,6 @@ class EditorMain(QMainWindow, QtStyleTools):
         # 讀取使用者顏色設定
         # Read user color settings
         read_user_color_setting()
-
-        # 字型資料庫
-        # Font database
-        self.font_database = QFontDatabase()
 
         # 建立 TabWidget (多分頁編輯器)
         # Create TabWidget (multi-tab editor)

--- a/je_editor/pyside_ui/main_ui/menu/file_menu/build_file_menu.py
+++ b/je_editor/pyside_ui/main_ui/menu/file_menu/build_file_menu.py
@@ -227,7 +227,9 @@ def add_font_menu(ui_we_want_to_set: EditorMain) -> None:
                         f"ui_we_want_to_set: {ui_we_want_to_set}")
     ui_we_want_to_set.file_menu.font_menu = ui_we_want_to_set.file_menu.addMenu(
         language_wrapper.language_word_dict.get("file_menu_font_label"))
-    for family in QFontDatabase().families():
+    # Qt6 的 QFontDatabase 全是靜態方法，建立實體已標為淘汰
+    # Every QFontDatabase member is static in Qt6; constructing one is deprecated
+    for family in QFontDatabase.families():
         font_action = QAction(family, parent=ui_we_want_to_set.file_menu.font_menu)
         font_action.triggered.connect(lambda checked=False, action=font_action: set_font(ui_we_want_to_set, action))
         ui_we_want_to_set.file_menu.font_menu.addAction(font_action)

--- a/je_editor/pyside_ui/main_ui/menu/text_menu/build_text_menu.py
+++ b/je_editor/pyside_ui/main_ui/menu/text_menu/build_text_menu.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from PySide6.QtGui import QAction
+from PySide6.QtGui import QAction, QFontDatabase
 from PySide6.QtWidgets import QMessageBox, QPlainTextEdit
 
 from je_editor.pyside_ui.main_ui.editor.editor_widget import EditorWidget
@@ -54,9 +54,11 @@ def set_text_menu(ui_we_want_to_set: EditorMain) -> None:
     ui_we_want_to_set.text_menu.font_menu = ui_we_want_to_set.text_menu.addMenu(
         language_wrapper.language_word_dict.get("text_menu_label_font"))
 
-    # 將系統支援的字型加入選單
-    # Add available system fonts into the menu
-    for family in ui_we_want_to_set.font_database.families():
+    # 將系統支援的字型加入選單。Qt6 的 QFontDatabase 全是靜態方法，建立實體已標為
+    # 淘汰，直接用類別呼叫即可。
+    # Add available system fonts into the menu. Every QFontDatabase member is
+    # static in Qt6 and constructing one is deprecated, so call it on the class.
+    for family in QFontDatabase.families():
         font_action = QAction(family, parent=ui_we_want_to_set.text_menu.font_menu)
         font_action.triggered.connect(
             lambda checked=False, action=font_action: set_font(ui_we_want_to_set, action))

--- a/je_editor/pyside_ui/main_ui/plugin_browser/github_api.py
+++ b/je_editor/pyside_ui/main_ui/plugin_browser/github_api.py
@@ -10,6 +10,7 @@ import json
 import urllib.request
 import urllib.error
 from pathlib import Path
+from urllib.parse import quote
 
 from je_editor.utils.logging.loggin_instance import jeditor_logger
 
@@ -28,16 +29,59 @@ def _assert_safe_url(url: str) -> None:
         raise ValueError(f"Rejected unsafe URL scheme: {url}")
 
 
-def fetch_repo_tree(owner: str, repo: str, branch: str = "main") -> list[dict]:
+def _safe_destination(dest_dir: str, file_name: str) -> Path:
+    """
+    組出下載目的地，並確認它真的落在 dest_dir 底下
+    Build the download destination and make sure it really is inside dest_dir.
+
+    檔名是遠端 repo 給的，不是使用者打的。``Path(dest_dir) / name`` 對 ``../x.py``
+    會往上跳，對 ``C:/Windows/x.py`` 這種絕對路徑更是直接換掉整個目錄——而插件之後
+    是會被匯入執行的，等於讓對方挑一個位置寫可執行的檔案。
+    The name comes from the remote repository, not from the user.
+    ``Path(dest_dir) / name`` walks upwards for ``../x.py`` and, for an absolute
+    path such as ``C:/Windows/x.py``, replaces the directory outright -- and a
+    plugin is later imported and run, so that hands the other side a choice of
+    where to write executable code.
+
+    兩種分隔符都擋，判斷才不會隨平台而異：``sub\\evil.py`` 在 Windows 上是路徑，
+    在 Linux 上卻是一個合法檔名。
+    Both separators are refused so the decision does not vary by platform:
+    ``sub\\evil.py`` is a path on Windows but a legal file name on Linux.
+
+    :param dest_dir: 插件目錄 / the plugins directory
+    :param file_name: 遠端給的檔名 / the file name the remote supplied
+    :return: 目的地路徑 / the destination path
+    :raises ValueError: 檔名逃出插件目錄時 / when the name escapes the plugins directory
+    """
+    if (not file_name or file_name != Path(file_name).name
+            or "/" in file_name or "\\" in file_name):
+        raise ValueError(f"Rejected unsafe plugin file name: {file_name!r}")
+    directory = Path(dest_dir).resolve()
+    destination = (directory / file_name).resolve()
+    if destination.parent != directory:
+        raise ValueError(f"Rejected unsafe plugin file name: {file_name!r}")
+    return destination
+
+
+def fetch_repo_tree(owner: str, repo: str, branch: str | None = None) -> list[dict]:
     """
     遞迴取得 GitHub Repo 的所有檔案清單。
     Recursively fetch all files from a GitHub repo.
 
+    :param owner: repo 擁有者 / the repository's owner
+    :param repo: repo 名稱 / the repository's name
+    :param branch: 要看哪一個分支，``None`` 表示該 repo 的預設分支
+        which branch to read, or ``None`` for the repository's default branch
     :return: 每個元素為 {"path": "...", "type": "blob"/"tree", "url": "...", "download_url": "..."}
              Each element: {"path": ..., "type": ..., "url": ..., "download_url": ...}
     """
     jeditor_logger.info(f"github_api.py fetch_repo_tree {owner}/{repo} branch={branch}")
     url = f"{_GITHUB_API}/repos/{owner}/{repo}/contents/"
+    # 不指定 ref 時 GitHub 走預設分支，這樣預設分支叫 master 的 repo 也讀得到
+    # Without a ref GitHub reads the default branch, so a repository whose
+    # default is called master is still readable
+    if branch:
+        url = f"{url}?ref={quote(branch, safe='')}"
     return _fetch_contents_recursive(url)
 
 
@@ -105,9 +149,10 @@ def download_plugin_file(download_url: str, dest_dir: str, file_name: str) -> st
     Download a plugin file to the specified directory.
 
     :return: 儲存的檔案路徑 / Saved file path
+    :raises ValueError: 檔名逃出插件目錄時 / when the name escapes the plugins directory
     """
     jeditor_logger.info(f"github_api.py download_plugin_file {download_url} -> {dest_dir}/{file_name}")
-    dest_path = Path(dest_dir) / file_name
+    dest_path = _safe_destination(dest_dir, file_name)
     content = _download_text(download_url)
     dest_path.write_text(content, encoding="utf-8")
     return str(dest_path)

--- a/je_editor/pyside_ui/main_ui/toolbar/toolbar_builder.py
+++ b/je_editor/pyside_ui/main_ui/toolbar/toolbar_builder.py
@@ -271,9 +271,12 @@ def _git_output(*arguments: str) -> str:
     :return: git 的標準輸出 / what git wrote to stdout
     :raises RuntimeError: git 回傳非零時 / when git exits non-zero
     """
-    # 固定可執行檔 "git" 加引數清單，沒有經過 shell
-    # A fixed "git" binary plus an argument list; no shell involved
-    result = subprocess.run(  # nosemgrep  # noqa: S603  # nosec B603
+    # 固定可執行檔 "git" 加引數清單，沒有經過 shell；依 PATH 找 git 是刻意的，使用者
+    # 裝在哪裡由他自己決定，git_cli.py 也是這樣叫的
+    # A fixed "git" binary plus an argument list, with no shell involved. Finding
+    # git on PATH is deliberate -- where it is installed is the user's business --
+    # and it is how git_cli.py calls it too.
+    result = subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603,B607
         ["git", *arguments],
         cwd=os.getcwd(),
         stdout=subprocess.PIPE,

--- a/je_editor/pyside_ui/main_ui/toolbar/toolbar_builder.py
+++ b/je_editor/pyside_ui/main_ui/toolbar/toolbar_builder.py
@@ -276,7 +276,7 @@ def _git_output(*arguments: str) -> str:
     # A fixed "git" binary plus an argument list, with no shell involved. Finding
     # git on PATH is deliberate -- where it is installed is the user's business --
     # and it is how git_cli.py calls it too.
-    result = subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603,B607
+    result = subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603 B607
         ["git", *arguments],
         cwd=os.getcwd(),
         stdout=subprocess.PIPE,

--- a/je_editor/pyside_ui/main_ui/toolbar/toolbar_builder.py
+++ b/je_editor/pyside_ui/main_ui/toolbar/toolbar_builder.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
+import subprocess  # nosec B404 - 呼叫 git 子命令皆以引數清單送入，未使用 shell
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt, QThread, QObject, Signal
+from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtGui import QAction, QIcon
 from PySide6.QtWidgets import (
     QToolBar, QComboBox, QStyle, QLabel, QWidget, QMessageBox
@@ -245,68 +247,138 @@ def _open_go_to_symbol(main_window: EditorMain) -> None:
     open_go_to_symbol(main_window)
 
 
-class _GitBranchWorker(QObject):
-    """背景取得 Git 分支清單 / Fetch git branches in background"""
-    finished = Signal(list, str)  # (branch_names, current_branch_or_sha)
-    error = Signal(str)
+# git 子命令的等待上限（秒）；掛在無回應的網路磁碟上時不要跟著卡住
+# Seconds to wait for a git subcommand, so an unresponsive network share does
+# not take the thread with it
+_GIT_TIMEOUT_SECONDS = 20
+
+
+def _git_output(*arguments: str) -> str:
+    """
+    在工作目錄執行一個 git 子命令並取得輸出
+    Run one git subcommand in the working directory and return its output.
+
+    這裡直接叫 git，而不是用 GitPython。``Repo`` 會帶起常駐的 ``git cat-file`` 子程
+    序與執行緒區域狀態，在背景執行緒裡反覆開關並不安穩；工具列只要兩行文字，一次
+    問完就結束的子程序剛好夠用，也是 ``git_cli.py`` 的做法。
+    This calls git directly rather than going through GitPython. A ``Repo``
+    brings up long-lived ``git cat-file`` children and thread-local state, and
+    opening and closing that repeatedly from a background thread is not steady.
+    The toolbar needs two pieces of text, so a subprocess that answers once and
+    exits is enough -- and it is what ``git_cli.py`` already does.
+
+    :param arguments: git 的引數 / the arguments to give git
+    :return: git 的標準輸出 / what git wrote to stdout
+    :raises RuntimeError: git 回傳非零時 / when git exits non-zero
+    """
+    # 固定可執行檔 "git" 加引數清單，沒有經過 shell
+    # A fixed "git" binary plus an argument list; no shell involved
+    result = subprocess.run(  # nosemgrep  # noqa: S603  # nosec B603
+        ["git", *arguments],
+        cwd=os.getcwd(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=_GIT_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"git {' '.join(arguments)} failed")
+    return result.stdout
+
+
+class _GitBranchScan(QThread):
+    """
+    背景取得 Git 分支清單
+    Fetch the git branch list in the background.
+
+    這裡是 ``QThread`` 的子類，而不是搬到執行緒上的 worker。編輯器其他地方的背景工
+    作都是這樣寫的，而且執行的物件就是執行緒本身——不會有「worker 被回收了但執行緒
+    還在」或是從別的執行緒銷毀它的問題。
+    A ``QThread`` subclass rather than a worker moved onto a thread. Every other
+    background job in the editor is written this way, and the object doing the
+    work is the thread itself -- so there is no worker to be collected out from
+    under a running thread, or destroyed from the wrong one.
+    """
+
+    # 名字不能叫 finished：那是 QThread 自己的訊號
+    # Not named finished: QThread has a signal by that name of its own
+    scanned = Signal(list, str)  # (branch_names, current_branch_or_sha)
+
+    def __init__(self) -> None:
+        super().__init__()
+        # 具名執行緒：萬一它在執行中被銷毀，Qt 的中止訊息才說得出是哪一條
+        # A named thread, so Qt's abort message says which one if it is ever
+        # destroyed while still running
+        self.setObjectName("ToolbarGitBranchScan")
 
     def run(self) -> None:
         try:
-            from git import Repo
-            import os
-            repo = Repo(os.getcwd(), search_parent_directories=True)
-            if repo.bare:
-                self.finished.emit([], "")
-                return
-            heads = [h.name for h in repo.heads]
-            try:
-                current = repo.active_branch.name
-            except TypeError:
-                current = repo.head.commit.hexsha[:8]
-            self.finished.emit(heads, current)
-        except Exception:
-            self.finished.emit([], "")
+            heads = [
+                line.strip() for line in
+                _git_output("branch", "--format=%(refname:short)").splitlines()
+                if line.strip()
+            ]
+            # detached HEAD 時 --abbrev-ref 回的是字面上的 "HEAD"，這時改顯示 sha
+            # On a detached HEAD --abbrev-ref answers the literal "HEAD", so the
+            # short sha is shown instead
+            current = _git_output("rev-parse", "--abbrev-ref", "HEAD").strip()
+            if current == "HEAD":
+                current = _git_output("rev-parse", "--short=8", "HEAD").strip()
+        except (OSError, RuntimeError, subprocess.SubprocessError) as error:
+            # 沒有 repo、壞掉的 repo、讀不到的磁碟都會走到這裡。分支欄空著就好，不
+            # 需要打斷使用者，但完全不留紀錄的話就查不出來了。
+            # No repository, a broken one, an unreadable drive: all land here. An
+            # empty branch box is a fine outcome and not worth interrupting anyone
+            # over, but leaving no trace at all makes it impossible to look into.
+            jeditor_logger.warning(f"Toolbar git branch scan failed: {error}")
+            self.scanned.emit([], "")
+            return
+        self.scanned.emit(heads, current)
 
 
-class _GitCheckoutWorker(QObject):
-    """背景執行 Git checkout / Run git checkout in background"""
-    finished = Signal()
-    error = Signal(str)
+class _GitCheckout(QThread):
+    """背景執行 Git checkout / Run git checkout in the background"""
+
+    checked_out = Signal()
+    failed = Signal(str)
 
     def __init__(self, target: str) -> None:
         super().__init__()
+        self.setObjectName("ToolbarGitCheckout")
         self._target = target
 
     def run(self) -> None:
         try:
-            from git import Repo
-            import os
-            repo = Repo(os.getcwd(), search_parent_directories=True)
-            repo.git.checkout(self._target)
-            self.finished.emit()
-        except Exception as e:
-            self.error.emit(str(e))
+            _git_output("checkout", self._target)
+        except (OSError, RuntimeError, subprocess.SubprocessError) as error:
+            self.failed.emit(str(error))
+            return
+        self.checked_out.emit()
 
 
 # 保持背景執行緒的引用，避免垃圾回收 / Keep thread references to prevent GC
-_bg_threads = []
+_bg_threads: list[QThread] = []
 
 
-def _run_in_background(worker: QObject, thread_parent: QObject) -> QThread:
-    """通用的背景執行緒啟動器 / Generic background thread runner"""
+def _run_in_background(thread: QThread) -> QThread:
+    """
+    記住一條背景執行緒並啟動它
+    Remember a background thread and start it.
+
+    引用一定要留著。沒有人抓著的話，Python 會在它還在跑的時候就回收掉，而銷毀一條
+    still-running 的 QThread 會讓 Qt 直接中止整個程序。
+    The reference has to be kept. With nobody holding it, Python collects it
+    while it is still running, and destroying a running QThread makes Qt abort
+    the process outright.
+
+    :param thread: 還沒啟動的執行緒 / the thread, not yet started
+    :return: 同一條執行緒 / that same thread
+    """
     global _bg_threads
-    thread = QThread(thread_parent)
-    # 具名執行緒：萬一它在執行中被銷毀，Qt 的中止訊息才說得出是哪一條
-    # A named thread, so Qt's abort message says which one if it is ever
-    # destroyed while still running
-    thread.setObjectName(f"Toolbar{type(worker).__name__}")
-    worker.moveToThread(thread)
-    thread.started.connect(worker.run)
-    worker.finished.connect(thread.quit)
-    if hasattr(worker, 'error'):
-        worker.error.connect(thread.quit)
-    thread.finished.connect(thread.deleteLater)
-    _bg_threads = [t for t in _bg_threads if t.isRunning()]
+    _bg_threads = [running for running in _bg_threads if running.isRunning()]
     _bg_threads.append(thread)
     thread.start()
     return thread
@@ -317,14 +389,13 @@ def stop_background_threads() -> int:
     等所有工具列的背景執行緒結束
     Wait for every toolbar background thread to finish.
 
-    這些執行緒掛在主視窗底下，視窗被銷毀時若還在跑，Qt 會直接讓程序中止
-    （``QThread: Destroyed while thread is still running``）。git 分支掃描在大的
-    或放在網路磁碟上的儲存庫要跑上一段時間，關閉時剛好還沒跑完並不罕見。
-    They hang off the main window, and Qt aborts the process outright
-    (``QThread: Destroyed while thread is still running``) if one is still going
-    when the window is destroyed. Scanning git branches takes a while on a large
-    repository or one on a network share, so still running at closing time is not
-    unusual.
+    還在跑的時候被銷毀，Qt 會直接讓程序中止（``QThread: Destroyed while thread is
+    still running``）。git 分支掃描在大的或放在網路磁碟上的儲存庫要跑上一段時間，
+    關閉時剛好還沒跑完並不罕見。
+    Destroyed while still running, they make Qt abort the process outright
+    (``QThread: Destroyed while thread is still running``). Scanning git branches
+    takes a while on a large repository or one on a network share, so still
+    running at closing time is not unusual.
 
     :return: 等了幾條執行緒 / how many threads were waited for
     """
@@ -343,11 +414,32 @@ def stop_background_threads() -> int:
     return waited
 
 
+def _a_branch_scan_is_running() -> bool:
+    """是否已經有一次分支掃描在跑 / Whether a branch scan is already going."""
+    return any(
+        isinstance(thread, _GitBranchScan) and thread.isRunning()
+        for thread in _bg_threads
+    )
+
+
 def _git_refresh_branches(main_window: EditorMain) -> None:
-    """重新載入 Git 分支清單 (背景執行) / Refresh git branch list in background"""
+    """
+    重新載入 Git 分支清單 (背景執行)
+    Refresh the git branch list in the background.
+
+    已經有一次在跑就跳過。這個函式在建立工具列時、切換分支之後、以及每次換語言
+    重建工具列時都會被呼叫，不擋的話一個大的儲存庫上會疊出好幾條同時掃描的執行緒，
+    而它們要的答案是一樣的。
+    A scan already going means this one is skipped. This runs when the toolbar is
+    built, after a checkout, and every time a language change rebuilds the
+    toolbar; unchecked, a large repository ends up with several scans at once, all
+    after the same answer.
+    """
+    if _a_branch_scan_is_running():
+        return
     combo: QComboBox = main_window.toolbar_branch_combo
 
-    worker = _GitBranchWorker()
+    scan = _GitBranchScan()
 
     def on_done(heads: list[str], current: str) -> None:
         combo.clear()
@@ -360,8 +452,8 @@ def _git_refresh_branches(main_window: EditorMain) -> None:
                 combo.setEditable(True)
                 combo.setEditText(current)
 
-    worker.finished.connect(on_done)
-    _run_in_background(worker, main_window)
+    scan.scanned.connect(on_done)
+    _run_in_background(scan)
 
 
 def _git_checkout(main_window: EditorMain) -> None:
@@ -371,7 +463,7 @@ def _git_checkout(main_window: EditorMain) -> None:
     if not target:
         return
 
-    worker = _GitCheckoutWorker(target)
+    checkout = _GitCheckout(target)
 
     def on_done() -> None:
         _git_refresh_branches(main_window)
@@ -385,6 +477,6 @@ def _git_checkout(main_window: EditorMain) -> None:
     def on_error(err: str) -> None:
         QMessageBox.critical(main_window, "Checkout Error", err)
 
-    worker.finished.connect(on_done)
-    worker.error.connect(on_error)
-    _run_in_background(worker, main_window)
+    checkout.checked_out.connect(on_done)
+    checkout.failed.connect(on_error)
+    _run_in_background(checkout)

--- a/je_editor/utils/file/open/open_file.py
+++ b/je_editor/utils/file/open/open_file.py
@@ -92,7 +92,7 @@ def read_file(file_path: Optional[str]) -> list[Path | str] | None:
         # 捕捉檔案 IO 與編碼例外
         # Catch file IO and encoding exceptions
         jeditor_logger.error(f"Failed to read file {file_path}: {e}")
-        raise JEditorOpenFileException
+        raise JEditorOpenFileException from e
     finally:
         # 確保鎖一定會被釋放
         # Ensure the lock is always released

--- a/je_editor/utils/file/save/save_file.py
+++ b/je_editor/utils/file/save/save_file.py
@@ -69,13 +69,15 @@ def write_file(file_path: str, content: str) -> None:
        Finally, release the lock.
     """
 
-    # 記錄日誌，方便除錯與追蹤
-    # Log the file path and content for debugging and tracking
+    content = str(content)  # 確保內容為字串 / Ensure content is a string
+
+    # 只記路徑與長度。內容曾經整份寫進日誌，等於把使用者編輯的每個檔案都抄一份到
+    # JEditor.log 裡。
+    # The path and a length, nothing more. This used to log the content itself,
+    # which copied every file the user edited into JEditor.log.
     jeditor_logger.info("save_file.py write_file "
                         f"file_path: {file_path} "
-                        f"content: {content}")
-
-    content = str(content)  # 確保內容為字串 / Ensure content is a string
+                        f"length: {len(content)}")
 
     try:
         _file_write_lock.acquire()  # 嘗試鎖定資源 / Acquire the lock
@@ -88,7 +90,7 @@ def write_file(file_path: str, content: str) -> None:
         # 捕捉檔案 IO 例外
         # Catch file IO exceptions
         jeditor_logger.error(f"Failed to write file {file_path}: {e}")
-        raise JEditorSaveFileException
+        raise JEditorSaveFileException from e
     finally:
         # 確保鎖一定會被釋放
         # Ensure the lock is always released

--- a/je_editor/utils/logging/loggin_instance.py
+++ b/je_editor/utils/logging/loggin_instance.py
@@ -1,9 +1,13 @@
 import logging
 from logging.handlers import RotatingFileHandler
 
-# 設定 root logger 的最低層級為 DEBUG
-# Set the root logger level to DEBUG
-logging.root.setLevel(logging.DEBUG)
+# root logger 不動。JEditor 會被別的程式嵌進去用，把 root 調成 DEBUG 等於替整個宿主
+# 程序決定了日誌層級；而這對自己也沒有用——下面的 logger 有自己的層級，記錄往上傳
+# 時只看各個 handler 的層級，不看 root 的。
+# The root logger is left alone. JEditor is embedded in other applications, so
+# putting root at DEBUG would decide the log level for the whole host process --
+# and it gains nothing here anyway: the logger below sets its own level, and
+# records travelling up are filtered by each handler's level, never by root's.
 
 # 建立一個名為 "JEditor" 的 logger
 # Create a logger named "JEditor"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,6 +27,23 @@ def qapp():
     yield app
 
 
+@pytest.fixture(autouse=True)
+def _no_toolbar_threads_left_running():
+    """
+    Wait for the toolbar's git scans before letting a test end.
+
+    Building a toolbar starts one, and the real window waits for them in its
+    close handler. A test that builds one and walks away leaves a thread running
+    into the next test, where Qt destroys it mid-flight and aborts the process.
+    Doing it here covers every test rather than each fixture remembering to.
+    """
+    yield
+    from je_editor.pyside_ui.main_ui.toolbar.toolbar_builder import (
+        stop_background_threads
+    )
+    stop_background_threads()
+
+
 @pytest.fixture()
 def tmp_dir(tmp_path):
     """Provide a temporary directory and chdir into it, restoring after."""

--- a/test/test_commit_diff.py
+++ b/test/test_commit_diff.py
@@ -1,0 +1,65 @@
+"""Tests for the patch a commit is shown to have made."""
+from __future__ import annotations
+
+import pytest
+
+from je_editor.git_client.git_action import GitService
+
+git = pytest.importorskip("git")
+
+
+@pytest.fixture()
+def service(tmp_path):
+    """A throw-away repository whose first commit adds a file, opened by the service."""
+    repository = git.Repo.init(tmp_path, initial_branch="main")
+    with repository.config_writer() as config:
+        config.set_value("user", "name", "Git Tester")
+        config.set_value("user", "email", "git@example.com")
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_text("first\n", encoding="utf-8")
+    repository.index.add(["tracked.txt"])
+    repository.index.commit("initial")
+    repository.close()
+    instance = GitService()
+    instance.open_repo(str(tmp_path))
+    yield instance, tmp_path
+    instance.close()
+
+
+def _commit(instance, root, text: str, message: str) -> str:
+    """Write ``text`` over the tracked file and commit it, returning the sha."""
+    (root / "tracked.txt").write_text(text, encoding="utf-8")
+    instance.repo.index.add(["tracked.txt"])
+    return instance.repo.index.commit(message).hexsha
+
+
+class TestTheDiffOfACommit:
+    def test_an_added_line_reads_as_an_addition(self, service):
+        instance, root = service
+        sha = _commit(instance, root, "first\nsecond\n", "add a line")
+        assert "+second" in instance.show_diff_of_commit(sha)
+
+    def test_an_added_line_is_not_reported_as_a_removal(self, service):
+        instance, root = service
+        sha = _commit(instance, root, "first\nsecond\n", "add a line")
+        assert "-second" not in instance.show_diff_of_commit(sha)
+
+    def test_a_removed_line_reads_as_a_removal(self, service):
+        instance, root = service
+        sha = _commit(instance, root, "", "empty the file")
+        assert "-first" in instance.show_diff_of_commit(sha)
+
+    def test_the_first_commit_reads_as_an_addition(self, service):
+        instance, _root = service
+        first = list(instance.repo.iter_commits())[-1]
+        assert "+first" in instance.show_diff_of_commit(first.hexsha)
+
+    def test_it_matches_what_git_itself_prints(self, service):
+        instance, root = service
+        sha = _commit(instance, root, "first\nsecond\n", "add a line")
+        printed = instance.repo.git.show("--format=", "--unified=0", sha)
+        changed = [line for line in printed.splitlines()
+                   if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))]
+        ours = [line for line in instance.show_diff_of_commit(sha).splitlines()
+                if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))]
+        assert ours == changed

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -161,7 +161,6 @@ class TestChoosingAtStartup:
 
 class TestTheLanguageMenu:
     def test_it_lists_every_shipped_language(self, qapp, qtbot):
-        from PySide6.QtGui import QFontDatabase
         from PySide6.QtWidgets import QMainWindow, QMenuBar, QTabWidget
         from je_editor.pyside_ui.main_ui.menu.language_menu.build_language_server import (
             set_language_menu
@@ -169,7 +168,6 @@ class TestTheLanguageMenu:
         window = QMainWindow()
         qtbot.addWidget(window)
         window.menu = QMenuBar()
-        window.font_database = QFontDatabase()
         window.tab_widget = QTabWidget()
         set_language_menu(window)
         assert set(window.language_menu.language_actions) >= set(SHIPPED)

--- a/test/test_logging_hygiene.py
+++ b/test/test_logging_hygiene.py
@@ -1,0 +1,84 @@
+"""Tests for what the editor writes to logs, and what it leaves alone."""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from je_editor.utils.file.save.save_file import write_file
+
+SECRET = "an unusually distinctive line the log must never carry"
+
+
+class TestSavingDoesNotLogTheFile:
+    """
+    A save records the path, not the file.
+
+    Logging the content copies every file the user edits into JEditor.log, and
+    the f-string builds that copy on every save whatever the log level is.
+    """
+
+    @pytest.fixture()
+    def written(self, tmp_path, caplog):
+        target = tmp_path / "saved.txt"
+        with caplog.at_level(logging.INFO, logger="JEditor"):
+            write_file(str(target), f"{SECRET}\n")
+        return caplog.text
+
+    def test_the_save_is_recorded(self, written):
+        assert "write_file" in written
+
+    def test_the_path_is_recorded(self, written):
+        assert "saved.txt" in written
+
+    def test_the_content_is_not_recorded(self, written):
+        assert SECRET not in written
+
+    def test_the_file_is_still_written(self, tmp_path):
+        target = tmp_path / "saved.txt"
+        write_file(str(target), f"{SECRET}\n")
+        assert target.read_text(encoding="utf-8") == f"{SECRET}\n"
+
+
+class TestImportingDoesNotReconfigureLogging:
+    """
+    Importing a module must not touch the root logger.
+
+    JEditor is embedded in other applications, and ``logging.basicConfig`` at
+    import time changes logging for the whole host process, not just this one.
+    A subprocess is used because under pytest the root logger already has
+    handlers, which makes ``basicConfig`` a silent no-op.
+    """
+
+    PROBE = textwrap.dedent(
+        """
+        import logging
+        before = (logging.root.level, len(logging.root.handlers))
+        import je_editor.pyside_ui.git_ui.git_client.git_branch_tree_widget  # noqa: F401
+        after = (logging.root.level, len(logging.root.handlers))
+        print(before, after)
+        """
+    )
+
+    @pytest.fixture(scope="class")
+    def probe_result(self):
+        finished = subprocess.run(
+            [sys.executable, "-c", self.PROBE],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=180,
+        )
+        if finished.returncode != 0:
+            pytest.skip(f"probe could not import the module: {finished.stderr[-400:]}")
+        before, after = finished.stdout.strip().rsplit(") (", 1)
+        return f"{before})", f"({after}"
+
+    def test_the_root_level_is_left_alone(self, probe_result):
+        before, after = probe_result
+        assert before.split(",")[0] == after.split(",")[0]
+
+    def test_no_root_handler_is_added(self, probe_result):
+        before, after = probe_result
+        assert before.split(",")[1] == after.split(",")[1]

--- a/test/test_logging_hygiene.py
+++ b/test/test_logging_hygiene.py
@@ -10,7 +10,7 @@ import pytest
 
 from je_editor.utils.file.save.save_file import write_file
 
-SECRET = "an unusually distinctive line the log must never carry"
+DISTINCTIVE_LINE = "an unusually distinctive line the log must never carry"
 
 
 class TestSavingDoesNotLogTheFile:
@@ -25,7 +25,7 @@ class TestSavingDoesNotLogTheFile:
     def written(self, tmp_path, caplog):
         target = tmp_path / "saved.txt"
         with caplog.at_level(logging.INFO, logger="JEditor"):
-            write_file(str(target), f"{SECRET}\n")
+            write_file(str(target), f"{DISTINCTIVE_LINE}\n")
         return caplog.text
 
     def test_the_save_is_recorded(self, written):
@@ -35,12 +35,12 @@ class TestSavingDoesNotLogTheFile:
         assert "saved.txt" in written
 
     def test_the_content_is_not_recorded(self, written):
-        assert SECRET not in written
+        assert DISTINCTIVE_LINE not in written
 
     def test_the_file_is_still_written(self, tmp_path):
         target = tmp_path / "saved.txt"
-        write_file(str(target), f"{SECRET}\n")
-        assert target.read_text(encoding="utf-8") == f"{SECRET}\n"
+        write_file(str(target), f"{DISTINCTIVE_LINE}\n")
+        assert target.read_text(encoding="utf-8") == f"{DISTINCTIVE_LINE}\n"
 
 
 class TestImportingDoesNotReconfigureLogging:
@@ -65,7 +65,9 @@ class TestImportingDoesNotReconfigureLogging:
 
     @pytest.fixture(scope="class")
     def probe_result(self):
-        finished = subprocess.run(
+        # This interpreter running a literal defined above; no shell, no input
+        # from anywhere outside this file.
+        finished = subprocess.run(  # nosemgrep  # noqa: S603  # nosec B603
             [sys.executable, "-c", self.PROBE],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=180,

--- a/test/test_plugin_download.py
+++ b/test/test_plugin_download.py
@@ -1,0 +1,74 @@
+"""Tests that a downloaded plugin can only land inside the plugins directory."""
+from __future__ import annotations
+
+import pytest
+
+from je_editor.pyside_ui.main_ui.plugin_browser import github_api
+from je_editor.pyside_ui.main_ui.plugin_browser.github_api import (
+    _safe_destination, download_plugin_file, fetch_repo_tree
+)
+
+# 遠端 repo 自己填的檔名，不是使用者打的
+# Names the remote repository fills in, not ones the user typed
+ESCAPING_NAMES = (
+    "../evil.py",
+    "../../evil.py",
+    "sub/evil.py",
+    "sub\\evil.py",
+    "C:/Windows/evil.py",
+    "/etc/evil.py",
+    "..",
+    "",
+)
+
+
+class TestTheDownloadDestination:
+    def test_a_plain_name_lands_in_the_directory(self, tmp_path):
+        assert _safe_destination(str(tmp_path), "good.py") == (tmp_path / "good.py").resolve()
+
+    @pytest.mark.parametrize("name", ESCAPING_NAMES)
+    def test_a_name_that_escapes_is_rejected(self, tmp_path, name):
+        with pytest.raises(ValueError):
+            _safe_destination(str(tmp_path), name)
+
+
+class TestDownloadingAPlugin:
+    @pytest.fixture(autouse=True)
+    def no_network(self, monkeypatch):
+        """Answer every download with a fixed body instead of reaching GitHub."""
+        monkeypatch.setattr(github_api, "_download_text", lambda url: "PLUGIN_NAME = 'x'\n")
+
+    def test_a_plain_name_is_written(self, tmp_path):
+        saved = download_plugin_file("https://example.invalid/x.py", str(tmp_path), "good.py")
+        assert (tmp_path / "good.py").read_text(encoding="utf-8") == "PLUGIN_NAME = 'x'\n"
+        assert saved == str((tmp_path / "good.py").resolve())
+
+    @pytest.mark.parametrize("name", ESCAPING_NAMES)
+    def test_an_escaping_name_writes_nothing(self, tmp_path, name):
+        destination = tmp_path / "plugins"
+        destination.mkdir()
+        with pytest.raises(ValueError):
+            download_plugin_file("https://example.invalid/x.py", str(destination), name)
+        assert list(tmp_path.rglob("*.py")) == []
+
+
+class TestTheBranchToRead:
+    @pytest.fixture()
+    def requested(self, monkeypatch):
+        """Record the URL asked for instead of reaching GitHub."""
+        seen = []
+        monkeypatch.setattr(github_api, "_fetch_contents_recursive",
+                            lambda url: seen.append(url) or [])
+        return seen
+
+    def test_no_branch_asks_for_the_default(self, requested):
+        fetch_repo_tree("owner", "repo")
+        assert "?ref=" not in requested[0]
+
+    def test_a_branch_is_asked_for_by_name(self, requested):
+        fetch_repo_tree("owner", "repo", "develop")
+        assert requested[0].endswith("?ref=develop")
+
+    def test_a_branch_name_is_escaped(self, requested):
+        fetch_repo_tree("owner", "repo", "feature/a b")
+        assert requested[0].endswith("?ref=feature%2Fa%20b")

--- a/test/test_retranslate.py
+++ b/test/test_retranslate.py
@@ -114,11 +114,9 @@ class TestNarrowingTheLookupToMenus:
 @pytest.fixture()
 def window(qapp, qtbot):
     """A window with the pieces retranslating touches."""
-    from PySide6.QtGui import QFontDatabase
     main_window = QMainWindow()
     qtbot.addWidget(main_window)
     main_window.menu = QMenuBar()
-    main_window.font_database = QFontDatabase()
     main_window.tab_widget = QTabWidget()
     main_window.setCentralWidget(main_window.tab_widget)
     main_window.encoding = "utf-8"
@@ -173,13 +171,11 @@ def full_window(window, english):
 @pytest.fixture()
 def window_factory(qtbot):
     """Make further bare windows, for comparing against a fresh build."""
-    from PySide6.QtGui import QFontDatabase
 
     def make() -> QMainWindow:
         main_window = QMainWindow()
         qtbot.addWidget(main_window)
         main_window.menu = QMenuBar()
-        main_window.font_database = QFontDatabase()
         main_window.tab_widget = QTabWidget()
         main_window.setCentralWidget(main_window.tab_widget)
         main_window.encoding = "utf-8"

--- a/test/test_text_menu_wiring.py
+++ b/test/test_text_menu_wiring.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtGui import QFontDatabase
 from PySide6.QtWidgets import QMainWindow, QMenuBar, QTabWidget
 
 # Every code_edit method name the Text menu dispatches to via _run_on_editor,
@@ -74,7 +73,6 @@ class TestTextMenuBuilds:
         from je_editor.pyside_ui.main_ui.menu.text_menu.build_text_menu import set_text_menu
         window = QMainWindow()
         window.menu = QMenuBar()
-        window.font_database = QFontDatabase()
         window.tab_widget = QTabWidget()
         set_text_menu(window)
         assert window.text_menu is not None

--- a/test/test_toolbar_actions.py
+++ b/test/test_toolbar_actions.py
@@ -187,11 +187,13 @@ class TestTheBranchScan:
 
     def test_a_detached_head_reports_a_sha(self, repository):
         import subprocess
-        sha = subprocess.run(
+        # Fixed arguments against the throw-away repository above; no shell.
+        sha = subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603,B607
             ["git", "rev-parse", "--short=8", "HEAD"], cwd=repository,
             capture_output=True, text=True, check=True).stdout.strip()
-        subprocess.run(["git", "checkout", "--detach", "HEAD"], cwd=repository,
-                       capture_output=True, check=True)
+        subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603,B607
+            ["git", "checkout", "--detach", "HEAD"], cwd=repository,
+            capture_output=True, check=True)
         _heads, current = _scan_result()
         assert current == sha
 

--- a/test/test_toolbar_actions.py
+++ b/test/test_toolbar_actions.py
@@ -188,10 +188,10 @@ class TestTheBranchScan:
     def test_a_detached_head_reports_a_sha(self, repository):
         import subprocess
         # Fixed arguments against the throw-away repository above; no shell.
-        sha = subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603,B607
+        sha = subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603 B607
             ["git", "rev-parse", "--short=8", "HEAD"], cwd=repository,
             capture_output=True, text=True, check=True).stdout.strip()
-        subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603,B607
+        subprocess.run(  # nosemgrep  # noqa: S603,S607  # nosec B603 B607
             ["git", "checkout", "--detach", "HEAD"], cwd=repository,
             capture_output=True, check=True)
         _heads, current = _scan_result()

--- a/test/test_toolbar_actions.py
+++ b/test/test_toolbar_actions.py
@@ -1,9 +1,13 @@
 """Tests that the toolbar wires up its actions with working labels and shortcuts."""
 from __future__ import annotations
 
+import gc
+import weakref
+
 import pytest
 from PySide6.QtWidgets import QMainWindow
 
+from je_editor.pyside_ui.main_ui.toolbar import toolbar_builder
 from je_editor.pyside_ui.main_ui.toolbar.toolbar_builder import (
     build_toolbar, stop_background_threads
 )
@@ -88,3 +92,117 @@ class TestToolbarActions:
             sequence = normalise_sequence(action.shortcut().toString())
             if sequence:
                 assert sequence in reserved, f"{sequence} is set but not reserved"
+
+
+@pytest.mark.usefixtures("qapp", "toolbar_window")
+class TestBackgroundScansOutliveTheirCaller:
+    """
+    A background scan has to be held somewhere once it is started.
+
+    Nothing but the caller's local refers to it, so dropped early it is
+    collected mid-run -- and destroying a running QThread makes Qt abort the
+    process. The branch box also stays empty, because the scan never reports.
+    """
+
+    def test_the_scan_is_not_collected_when_the_caller_returns(self):
+        stop_background_threads()
+        reference = self._start_and_drop()
+        gc.collect()
+        assert reference() is not None
+        stop_background_threads()
+
+    def test_the_scan_reports_after_the_caller_returns(self, qtbot):
+        stop_background_threads()
+        reported = []
+
+        # Connecting a callback does not keep the scan alive -- it owns the
+        # connection, not the other way round -- so this still drops it.
+        scan = toolbar_builder._GitBranchScan()
+        scan.scanned.connect(lambda heads, current: reported.append(current))
+        toolbar_builder._run_in_background(scan)
+        del scan
+        gc.collect()
+
+        qtbot.waitUntil(lambda: bool(reported), timeout=15000)
+        stop_background_threads()
+
+    def test_the_scan_is_released_once_the_wait_is_over(self):
+        # Held until it has run, but not held forever -- every refresh would
+        # otherwise leave a thread behind for the life of the window.
+        stop_background_threads()
+        reference = self._start_and_drop()
+        stop_background_threads()
+        gc.collect()
+        assert reference() is None
+
+    @staticmethod
+    def _start_and_drop() -> weakref.ref:
+        """Start a scan the way the real call sites do, keeping only a weak reference."""
+        scan = toolbar_builder._GitBranchScan()
+        toolbar_builder._run_in_background(scan)
+        return weakref.ref(scan)
+
+
+@pytest.fixture()
+def repository(tmp_path, monkeypatch):
+    """A throw-away repository with two branches, and the toolbar looking at it."""
+    git = pytest.importorskip("git")
+    made = git.Repo.init(tmp_path, initial_branch="main")
+    with made.config_writer() as config:
+        config.set_value("user", "name", "Git Tester")
+        config.set_value("user", "email", "git@example.com")
+    (tmp_path / "tracked.txt").write_text("first\n", encoding="utf-8")
+    made.index.add(["tracked.txt"])
+    made.index.commit("initial")
+    made.create_head("side")
+    made.close()
+    # The scan reads whatever repository the working directory sits in.
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _scan_result() -> tuple:
+    """Run one scan on this thread and return what it reported."""
+    reported = []
+    scan = toolbar_builder._GitBranchScan()
+    scan.scanned.connect(lambda heads, current: reported.append((heads, current)))
+    scan.run()
+    return reported[0]
+
+
+@pytest.mark.usefixtures("qapp")
+class TestTheBranchScan:
+    """
+    What the branch box is filled from. This never ran until the scan was held
+    onto properly, so the reading itself had never been checked.
+    """
+
+    def test_it_lists_the_branches(self, repository):
+        heads, _current = _scan_result()
+        assert sorted(heads) == ["main", "side"]
+
+    def test_it_names_the_branch_that_is_checked_out(self, repository):
+        _heads, current = _scan_result()
+        assert current == "main"
+
+    def test_a_detached_head_reports_a_sha(self, repository):
+        import subprocess
+        sha = subprocess.run(
+            ["git", "rev-parse", "--short=8", "HEAD"], cwd=repository,
+            capture_output=True, text=True, check=True).stdout.strip()
+        subprocess.run(["git", "checkout", "--detach", "HEAD"], cwd=repository,
+                       capture_output=True, check=True)
+        _heads, current = _scan_result()
+        assert current == sha
+
+    def test_somewhere_that_is_not_a_repository_reports_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert _scan_result() == ([], "")
+
+    def test_a_subdirectory_still_finds_the_repository(self, repository, monkeypatch):
+        nested = repository / "deep" / "deeper"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        heads, current = _scan_result()
+        assert sorted(heads) == ["main", "side"]
+        assert current == "main"


### PR DESCRIPTION
A scan of the project turned up five defects; each commit is one of them.

**The toolbar's git branch box never filled.** `_run_in_background` kept a
reference to the background thread but not to the worker moved onto it, and
`thread.started` — the only other thing referring to that worker — is held by
weak reference for a bound method. The worker was collected as soon as the
caller returned, so `run()` never executed, `finished` never fired, and the
thread sat in its event loop until Qt aborted the process over it. It is now a
QThread subclass, matching how every other background job here is written.

Reading the branches also moved off GitPython onto `git` directly. A `Repo`
brings up long-lived `cat-file` children and thread-local state; opening and
closing that from a background thread aborted the suite on Windows in three
runs out of three, while the subprocess form passes three out of three.

**A downloaded plugin could land anywhere.** The file name came from the
GitHub API response and went straight into `Path(dest_dir) / file_name`, so
`../evil.py` walked out of the plugins directory and `C:/Windows/x.py`
replaced it — and plugins are imported and run.

**Commit diffs were printed backwards.** `commit.diff(parent)` is the inverse
of what a commit did; additions showed as removals. Now verified against what
`git show` prints.

**The editor logged file contents and reconfigured logging for its host.**
`write_file` built a copy of every saved file for a log line, and two modules
set root logging at import — which decides the level for whatever application
embeds JEditor.

**Deprecated Qt calls and silent exception handlers** are cleared out.

Verified with `ruff check` clean and the full suite run three times: 1859
passed each time, against a 1819-test baseline confirmed stable over three
runs beforehand.
